### PR TITLE
Create run.bat

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,3 @@
+chcp 65001
+python run.py
+Pause


### PR DESCRIPTION
is japanese enviroment. error `UnicodeEncodeError: 'cp932' codec can't encode character '\u2588' in position 11: illegal multibyte sequence`  is run. so incident.